### PR TITLE
Do not show the free disk space on the desktop

### DIFF
--- a/DiskUsageLocationWidget.py
+++ b/DiskUsageLocationWidget.py
@@ -42,6 +42,8 @@ class DiskUsageLocationWidget(GObject.GObject, Nautilus.LocationWidgetProvider):
         return stat.f_bavail*stat.f_bsize
 
     def get_widget(self, uri, window):
+        if type(window).__name__ == "NautilusDesktopWindow" :
+            return None
         entry = Gtk.Entry()
         full_url = urlparse(uri)
         file_url = full_url.path


### PR DESCRIPTION
If nautilus manages the desktop, the free diskspace is shown in a quite big status bar over the whole desktop. Most people probably do not want this, so if the window class is "NautilusDesktopWindow" (tested in ubuntu 16.04)  no widget is returned.